### PR TITLE
feat(services): one frame API interpreters

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,18 +1,1 @@
-{
-    "name": "sbt",
-    "version": "1.8.0",
-    "bspVersion": "2.1.0-M1",
-    "languages": [
-        "scala"
-    ],
-    "argv": [
-        "/opt/homebrew/Cellar/openjdk@17/17.0.12/libexec/openjdk.jdk/Contents/Home/bin/java",
-        "-Xms100m",
-        "-Xmx100m",
-        "-classpath",
-        "/opt/homebrew/Cellar/sbt/1.10.2/libexec/bin/sbt-launch.jar",
-        "-Dsbt.script=/opt/homebrew/Cellar/sbt/1.10.2/libexec/bin/sbt",
-        "xsbt.boot.Boot",
-        "-bsp"
-    ]
-}
+{"name":"sbt","version":"1.8.0","bspVersion":"2.1.0-M1","languages":["scala"],"argv":["/opt/homebrew/Cellar/openjdk@17/17.0.12/libexec/openjdk.jdk/Contents/Home/bin/java","-Xms100m","-Xmx100m","-classpath","/opt/homebrew/Cellar/sbt/1.10.2/libexec/bin/sbt-launch.jar","-Dsbt.script=/opt/homebrew/Cellar/sbt/1.10.2/libexec/bin/sbt","xsbt.boot.Boot","-bsp"]}

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 # Ignore sbt specific files
+.metals/
+.bloop/
 target/
+project/.bloop
 project/target/
 project/project/
 
-# IntelliJ IDEA files
+# IDE Files
+.vscode/
 .idea/
 *.iws
 *.iml

--- a/build.sbt
+++ b/build.sbt
@@ -53,9 +53,11 @@ libraryDependencies ++= Seq(
   compilerPlugin(Libraries.kindProjector),
   Libraries.cats,
   Libraries.catsEffect,
+  Libraries.ci,
   Libraries.fs2,
   Libraries.http4sDsl,
   Libraries.http4sServer,
+  Libraries.http4sClient,
   Libraries.http4sCirce,
   Libraries.circeCore,
   Libraries.circeGeneric,
@@ -65,5 +67,5 @@ libraryDependencies ++= Seq(
   Libraries.logback,
   Libraries.scalaTest      % Test,
   Libraries.scalaCheck     % Test,
-  Libraries.catsScalaCheck % Test
+  Libraries.catsScalaCheck % Test,
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
   object Versions {
     val cats       = "2.6.1"
     val catsEffect = "2.5.1"
+    val ci         = "1.4.0"
     val fs2        = "2.5.4"
     val http4s     = "0.22.15"
     val circe      = "0.14.2"
@@ -23,22 +24,23 @@ object Dependencies {
 
     lazy val cats       = "org.typelevel" %% "cats-core"   % Versions.cats
     lazy val catsEffect = "org.typelevel" %% "cats-effect" % Versions.catsEffect
+    lazy val ci         = "org.typelevel" %% "case-insensitive" % Versions.ci
     lazy val fs2        = "co.fs2"        %% "fs2-core"    % Versions.fs2
-
     lazy val http4sDsl       = http4s("http4s-dsl")
     lazy val http4sServer    = http4s("http4s-blaze-server")
+    lazy val http4sClient    = http4s("http4s-blaze-client")
     lazy val http4sCirce     = http4s("http4s-circe")
     lazy val circeCore       = circe("circe-core")
     lazy val circeGeneric    = circe("circe-generic")
     lazy val circeGenericExt = circe("circe-generic-extras")
     lazy val circeParser     = circe("circe-parser")
     lazy val pureConfig      = "com.github.pureconfig" %% "pureconfig" % Versions.pureConfig
-
+ 
     // Compiler plugins
     lazy val kindProjector = "org.typelevel" %% "kind-projector" % Versions.kindProjector cross CrossVersion.full
 
     // Runtime
-    lazy val logback = "ch.qos.logback" % "logback-classic" % Versions.logback
+    lazy val logback = "ch.qos.logback" % "logback-classic" % Versions.logback // logger
 
     // Test
     lazy val scalaTest      = "org.scalatest"     %% "scalatest"       % Versions.scalaTest

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,8 @@
+// format: off
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.6.0")
+
+// format: on

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,8 +1,17 @@
 app {
   http {
     host = "0.0.0.0"
-    port = 8080
+    port = 8090
     timeout = 40 seconds
+  }
+  one-frame {
+    http = {
+      host = "127.0.0.1"
+      port = 8080
+      timeout = 5 seconds
+    }
+    token = "10dc303535874aeccc86a8251e6992f5",
+    pair-path = "/rates",
   }
 }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,5 +10,6 @@
     </root>
 
     <logger name="http4s"/>
+    <logger name="forex.services.rates.interpreters" level="debug"/>
   </configuration>
 

--- a/src/main/scala/forex/Main.scala
+++ b/src/main/scala/forex/Main.scala
@@ -19,9 +19,10 @@ class Application[F[_]: ConcurrentEffect: Timer] {
     for {
       config <- Config.stream("app")
       module = new Module[F](config)
+      httpApp <- Stream.resource(module.httpApp)
       _ <- BlazeServerBuilder[F](ec)
             .bindHttp(config.http.port, config.http.host)
-            .withHttpApp(module.httpApp)
+            .withHttpApp(httpApp)
             .serve
     } yield ()
 

--- a/src/main/scala/forex/config/ApplicationConfig.scala
+++ b/src/main/scala/forex/config/ApplicationConfig.scala
@@ -4,10 +4,17 @@ import scala.concurrent.duration.FiniteDuration
 
 case class ApplicationConfig(
     http: HttpConfig,
+    oneFrame: OneFrame,
 )
 
 case class HttpConfig(
     host: String,
     port: Int,
     timeout: FiniteDuration
+)
+
+case class OneFrame (
+    http: HttpConfig,
+    token: String,
+    pairPath: String,
 )

--- a/src/main/scala/forex/domain/Currency.scala
+++ b/src/main/scala/forex/domain/Currency.scala
@@ -1,6 +1,8 @@
 package forex.domain
 
 import cats.Show
+import io.circe.Decoder
+import io.circe.HCursor
 
 sealed trait Currency
 
@@ -39,4 +41,9 @@ object Currency {
     case "USD" => USD
   }
 
+  implicit val currencyDecoder: Decoder[Currency] = new Decoder[Currency] {
+    final def apply(c: HCursor): Decoder.Result[Currency] =
+      c.as[String].map(Currency.fromString)
+  }
 }
+

--- a/src/main/scala/forex/domain/Price.scala
+++ b/src/main/scala/forex/domain/Price.scala
@@ -1,8 +1,11 @@
 package forex.domain
+import io.circe.Decoder
 
 case class Price(value: BigDecimal) extends AnyVal
 
 object Price {
   def apply(value: Integer): Price =
     Price(BigDecimal(value))
+
+  implicit val priceDecoder: Decoder[Price] = Decoder[BigDecimal].map(Price(_))
 }

--- a/src/main/scala/forex/services/rates/Interpreters.scala
+++ b/src/main/scala/forex/services/rates/Interpreters.scala
@@ -1,8 +1,12 @@
 package forex.services.rates
 
+import forex.config.ApplicationConfig
 import cats.Applicative
+import cats.effect.Sync
 import interpreters._
+import org.http4s.client.Client
 
 object Interpreters {
   def dummy[F[_]: Applicative]: Algebra[F] = new OneFrameDummy[F]()
+  def api[F[_]: Sync](client: Client[F], config: ApplicationConfig): Algebra[F] = new OneFrameAPI[F](client, config)
 }

--- a/src/main/scala/forex/services/rates/interpreters/OneFrameAPI.scala
+++ b/src/main/scala/forex/services/rates/interpreters/OneFrameAPI.scala
@@ -1,0 +1,82 @@
+package forex.services.rates.interpreters
+
+import forex.domain.{ Currency, Price, Rate, Timestamp }
+import forex.services.rates.errors._
+import forex.services.rates.Algebra
+import forex.config.ApplicationConfig
+
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.applicativeError._ // for attempt
+import cats.syntax.either._
+import cats.syntax.applicative._
+import org.http4s.circe.CirceEntityDecoder._
+import org.http4s.client.Client
+import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.Method._
+import org.http4s._
+import io.circe.generic.auto._
+import org.typelevel.ci.CIString
+import org.slf4j.LoggerFactory
+//import scala.concurrent.duration._
+
+// Define a case class to map the JSON response from the API
+final case class RateResponse(
+  from: Currency,
+  to: Currency,
+  price: BigDecimal,
+  time_stamp: String
+)
+
+class OneFrameAPI[F[_]: Sync](client: Client[F], config: ApplicationConfig) extends Algebra[F] with Http4sClientDsl[F] {
+    // Build the request URI based on the pair
+    private def buildUri(baseUri:Uri,pair: Rate.Pair): Uri = baseUri.withQueryParam("pair", s"${pair.from}${pair.to}")
+    private val token: String = config.oneFrame.token
+    private val baseUri: Uri = Uri.unsafeFromString(s"http://${config.oneFrame.http.host}:${config.oneFrame.http.port}${config.oneFrame.pairPath}")
+    val logger = LoggerFactory.getLogger(this.getClass)
+    
+    override def get(pair: Rate.Pair): F[Error Either Rate] = {
+      
+      // Create an HTTP request with headers
+      val request = GET(
+        buildUri(baseUri, pair),
+        Header.Raw.apply(CIString("token"), token)
+      )
+
+      // Log the request details (URI and headers)
+      logger.info(s"Created request with URI: ${request.uri}")
+      logger.info(s"Headers: ${request.headers}")
+      // Send the request and handle the response
+      client.run(request).use { response =>
+        response.status match {
+          case Status.Ok => 
+            response.as[List[RateResponse]].attempt.flatMap{ 
+              case Right(rateResponses) =>
+                logger.debug(s"Successfully decoded response: ${rateResponses}")
+                val rateResponse = rateResponses.head
+                val rate = Rate(
+                  pair = Rate.Pair(rateResponse.from, rateResponse.to),
+                  price = Price(rateResponse.price),
+                  timestamp = Timestamp.now // You can parse `rateResponse.time_stamp` here
+                )
+                rate.asRight[Error].pure[F]
+
+              case Left(error) =>
+                logger.error(s"Failed to decode response: ${error.getMessage}")
+                Error.OneFrameLookupFailed("Failed to decode API response").asLeft[Rate].leftMap(identity[Error]).pure[F]
+            }
+
+          case Status.BadRequest =>
+            logger.debug("400")
+            Error.OneFrameLookupFailed("Bad Request").asLeft[Rate].leftMap(identity[Error]).pure[F]
+
+          case Status.Unauthorized =>
+            logger.debug("403")
+            Error.OneFrameLookupFailed("Unauthorized").asLeft[Rate].leftMap(identity[Error]).pure[F]
+          case unexpectedStatus => 
+            logger.debug(s"Unexpected status code: $unexpectedStatus")
+            Error.OneFrameLookupFailed("Unexpected response from the API").asLeft[Rate].leftMap(identity[Error]).pure[F]
+        }
+    }
+  }
+}


### PR DESCRIPTION
Motivation: 
first time involve in scala project. try to create new class in purpose to do http call to the upstream. 

Changes: 
- added new config declaration for oneFrameAPI
- New Class OneFrameAPI 
   - define response struct
   - create http client from org.http4s.client.Client
   - handle the response with custom decoder to response struct. 
   - map the response to Output function 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new configuration section for handling one-frame-specific settings, including HTTP settings and token management.
	- Added new HTTP client capabilities for fetching foreign exchange rates.
	- Implemented a new API for handling exchange rate requests with enhanced error handling and logging.

- **Bug Fixes**
	- Updated the HTTP port configuration for improved service accessibility.

- **Documentation**
	- Enhanced comments and structure in the configuration files for better clarity on settings.

- **Chores**
	- Updated `.gitignore` to include additional entries for build tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->