### PR TITLE
feat(callwrapper): cb and simple memCache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:11
+WORKDIR /app
+COPY ./target/scala-2.13/my-service.jar .
+ENTRYPOINT ["java", "-jar", "my-service.jar"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,51 @@
-# forex-mtl
+# Forex-mtl
 
-Live interpeter from one time service. 
-the application will provide you this logic 
+This project is a live interpreter for a one-frame service that provides exchange rate information. The application operates under the following logic:
 
-/* */
-The service returns an exchange rate when provided with 2 supported currencies
-The rate should not be older than 5 minutes
-The service should support at least 10,000 successful requests per day with 1 API token
+1. The service returns the exchange rate when two supported currencies are provided.
+2. The exchange rate must not be older than 5 minutes.
+3. The service is designed to handle at least 10,000 successful requests per day with a single API token.
 
-one-service API can just only serve 1000 call per day. 
+Please note that the one-service API has a limitation of 1,000 calls per day.
 
-#How to run this local project 
-- run one frame service with 'docker-compose up -d'
-- Compile n run the Project
-    -  enter sbt console
-    -  execute compile
-    -  run
-- Run Testing 
-    - test -> via sbt console. 
+## How to Run This Project Locally
+1. Start the One Frame service by running `docker-compose up -d`.
+2. Compile and run the project:
+    - Enter the SBT console.
+    - Execute the `compile` command.
+    - Run the application.
+3. Execute tests via the SBT console.
 
+# Detailed Solution
+TBA
+
+# Technical Overview
+In this project, I tried to implement these technical aspect to achieve good microservice standard.
+## Frameworks and Libraries
+- **HTTP Framework**: http4s
+- **Configuration Management**: PureConfig
+- **Circuit Breaker and Resilience**: Utilize Resilience4j Circuit Breaker patterns to ensure resilient communication between services and gracefully handle failures.
+- **Asynchronous and Non-blocking IO**: Leverage Scala's functional programming ecosystem, utilizing libraries such as Cats Effect, ZIO, or Monix for effective concurrency management, non-blocking I/O, and error handling.
+
+## Resilience and Fault Tolerance
+- Implement the Circuit Breaker pattern to prevent cascading failures across services.
+~~- Introduce the SingleFlight mechanism to optimize redundant requests.~~ Can't develop the SingleFlight because dependencies version issue. 
+
+## Testing
+- **Unit Testing**: Employ ScalaTest or MUnit for unit testing individual functions and logic.
+- **Coverage**: TBA %
+
+## Observability (Logging, Monitoring, and Tracing)
+- **Structured Logging**: Use Logback to implement structured logging, ideally in JSON format.
+- **Metrics and Monitoring**: Integrate with Prometheus for metrics collection and Grafana for monitoring dashboards. Utilize libraries like Micrometer to export JVM metrics (memory, CPU usage, thread pools).
+- **Distributed Tracing**: Employ tracing libraries such as OpenTelemetry or Zipkin to monitor requests across distributed services, aiding in performance tracking and troubleshooting.
+
+## Caching
+- **Caching**: Implement Memcached to cache frequently accessed data, improving response times and reducing database load.
+
+## Security
+- **Data Validation**: Ensure robust data validation.
+- **HTTPS**: Ensure secure communication with other microservices in a production environment.
+
+## Continuous Integration and Continuous Deployment (CI/CD)
+- Establish CI/CD pipelines using tools like GitHub Actions to automate testing, building, and deployment within this microservice's architecture.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please note that the one-service API has a limitation of 1,000 calls per day.
 TBA
 
 # Technical Overview
-In this project, I tried to implement these technical aspect to achieve good microservice standard.
+In this project, I tried to implement these technical aspects to achieve a good microservice standard.
 ## Frameworks and Libraries
 - **HTTP Framework**: http4s
 - **Configuration Management**: PureConfig
@@ -29,7 +29,7 @@ In this project, I tried to implement these technical aspect to achieve good mic
 
 ## Resilience and Fault Tolerance
 - Implement the Circuit Breaker pattern to prevent cascading failures across services.
-~~- Introduce the SingleFlight mechanism to optimize redundant requests.~~ Can't develop the SingleFlight because dependencies version issue. 
+- ~~Introduce the SingleFlight mechanism to optimize redundant requests.~~ The SingleFlight mechanism could not be implemented due to dependency version conflicts. This feature may be added in the future when compatibility issues are resolved.
 
 ## Testing
 - **Unit Testing**: Employ ScalaTest or MUnit for unit testing individual functions and logic.

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ libraryDependencies ++= Seq(
   Libraries.circeGenericExt,
   Libraries.circeParser,
   Libraries.pureConfig,
+  Libraries.circuitBreaker,
   Libraries.logback,
   Libraries.scalaTest      % Test,
   Libraries.scalaCheck     % Test,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,4 +5,4 @@ services:
     image: paidyinc/one-frame
     container_name: one-frame-service
     ports:
-      - "8080:8080"
+      - "8090:8080"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
     val http4s     = "0.22.15"
     val circe      = "0.14.2"
     val pureConfig = "0.17.4"
+    val cb         = "2.2.0"
 
     val kindProjector  = "0.13.2"
     val logback        = "1.2.3"
@@ -35,7 +36,10 @@ object Dependencies {
     lazy val circeGenericExt = circe("circe-generic-extras")
     lazy val circeParser     = circe("circe-parser")
     lazy val pureConfig      = "com.github.pureconfig" %% "pureconfig" % Versions.pureConfig
- 
+
+    // Resiliency
+    lazy val circuitBreaker = "io.github.resilience4j" % "resilience4j-circuitbreaker" % Versions.cb
+
     // Compiler plugins
     lazy val kindProjector = "org.typelevel" %% "kind-projector" % Versions.kindProjector cross CrossVersion.full
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -13,8 +13,8 @@ app {
     call-wrapper = {
       cb-name = "one-frame-cb",
       failure-rate-threshold = 50,
-      wait-duration-in-open-state = 60,
-      cache-ttl = 300,
+      wait-duration-in-open-state = 60 seconds,
+      cache-ttl = 300 seconds,
       enable-cb = true,
       enable-cache = true
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,14 +1,22 @@
 app {
   http {
     host = "0.0.0.0"
-    port = 8090
+    port = 8080
     timeout = 40 seconds
   }
   one-frame {
     http = {
-      host = "127.0.0.1"
-      port = 8080
+      host = "http://127.0.0.1"
+      port = 8090
       timeout = 5 seconds
+    }
+    call-wrapper = {
+      cb-name = "one-frame-cb",
+      failure-rate-threshold = 50,
+      wait-duration-in-open-state = 60,
+      cache-ttl = 300,
+      enable-cb = true,
+      enable-cache = true
     }
     token = "10dc303535874aeccc86a8251e6992f5",
     pair-path = "/rates",

--- a/src/main/scala/forex/config/ApplicationConfig.scala
+++ b/src/main/scala/forex/config/ApplicationConfig.scala
@@ -13,8 +13,23 @@ case class HttpConfig(
     timeout: FiniteDuration
 )
 
+// * cbName: the name of caller function / usecase
+// * failureRateThreshold: the failure rate in percentage to open the CB
+// * waitDurationInOpenState: waiting time from CB to let upstream service recover / ready to serve again.
+// * cacheTTL: cache time to live in second
+case class CallWrapperConfig(
+    cbName: String,
+    failureRateThreshold: Int,
+    waitDurationInOpenState: Long,
+    cacheTTL: Long,
+    enableCb: Boolean = false, // Optional cb parameter
+    enableCache: Boolean = false // Optional cache parameter
+)
+
+
 case class OneFrame (
     http: HttpConfig,
+    callWrapper: CallWrapperConfig,
     token: String,
     pairPath: String,
 )

--- a/src/main/scala/forex/config/ApplicationConfig.scala
+++ b/src/main/scala/forex/config/ApplicationConfig.scala
@@ -13,17 +13,23 @@ case class HttpConfig(
     timeout: FiniteDuration
 )
 
-// * cbName: the name of caller function / usecase
-// * failureRateThreshold: the failure rate in percentage to open the CB
-// * waitDurationInOpenState: waiting time from CB to let upstream service recover / ready to serve again.
-// * cacheTTL: cache time to live in second
+/**
+ * Configuration for the call wrapper.
+ *
+ * @param cbName The name of the caller function or use case
+ * @param failureRateThreshold The failure rate threshold (in percentage) to open the circuit breaker
+ * @param waitDurationInOpenState The waiting time for the circuit breaker to allow upstream service recovery
+ * @param cacheTTL The cache time-to-live
+ * @param enableCb Whether to enable the circuit breaker
+ * @param enableCache Whether to enable caching
+ */
 case class CallWrapperConfig(
-    cbName: String,
-    failureRateThreshold: Int,
-    waitDurationInOpenState: Long,
-    cacheTTL: Long,
-    enableCb: Boolean = false, // Optional cb parameter
-    enableCache: Boolean = false // Optional cache parameter
+  cbName: String,
+  failureRateThreshold: Int,
+  waitDurationInOpenState: FiniteDuration,
+  cacheTTL: FiniteDuration,
+  enableCb: Boolean = false,
+  enableCache: Boolean = false
 )
 
 

--- a/src/main/scala/forex/services/rates/interpreters/OneFrameAPI.scala
+++ b/src/main/scala/forex/services/rates/interpreters/OneFrameAPI.scala
@@ -1,13 +1,12 @@
 package forex.services.rates.interpreters
 
-import forex.domain.{ Currency, Price, Rate, Timestamp }
+import forex.domain.{Currency, Price, Rate, Timestamp}
 import forex.services.rates.errors._
 import forex.services.rates.Algebra
 import forex.config.ApplicationConfig
-
 import cats.effect.Sync
 import cats.syntax.flatMap._
-import cats.syntax.applicativeError._ // for attempt
+import cats.syntax.applicativeError._
 import cats.syntax.either._
 import cats.syntax.applicative._
 import org.http4s.circe.CirceEntityDecoder._
@@ -17,40 +16,46 @@ import org.http4s.Method._
 import org.http4s._
 import io.circe.generic.auto._
 import org.typelevel.ci.CIString
-import org.slf4j.LoggerFactory
-//import scala.concurrent.duration._
+import org.slf4j.{Logger, LoggerFactory}
+import forex.utils.callWrapper.CallWrapper
 
 // Define a case class to map the JSON response from the API
 final case class RateResponse(
-  from: Currency,
-  to: Currency,
-  price: BigDecimal,
-  time_stamp: String
+ from: Currency,
+ to: Currency,
+ price: BigDecimal,
+ time_stamp: String
 )
 
 class OneFrameAPI[F[_]: Sync](client: Client[F], config: ApplicationConfig) extends Algebra[F] with Http4sClientDsl[F] {
-    // Build the request URI based on the pair
-    private def buildUri(baseUri:Uri,pair: Rate.Pair): Uri = baseUri.withQueryParam("pair", s"${pair.from}${pair.to}")
-    private val token: String = config.oneFrame.token
-    private val baseUri: Uri = Uri.unsafeFromString(s"http://${config.oneFrame.http.host}:${config.oneFrame.http.port}${config.oneFrame.pairPath}")
-    val logger = LoggerFactory.getLogger(this.getClass)
-    
-    override def get(pair: Rate.Pair): F[Error Either Rate] = {
-      
-      // Create an HTTP request with headers
-      val request = GET(
-        buildUri(baseUri, pair),
-        Header.Raw.apply(CIString("token"), token)
-      )
+  // Build the request URI based on the pair
+  private def buildUri(baseUri:Uri,pair: Rate.Pair): Uri = baseUri.withQueryParam("pair", s"${pair.from}${pair.to}")
+  private val token: String = config.oneFrame.token
+  private val baseUri: Uri = Uri.unsafeFromString(s"${config.oneFrame.http.host}:${config.oneFrame.http.port}${config.oneFrame.pairPath}")
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-      // Log the request details (URI and headers)
-      logger.info(s"Created request with URI: ${request.uri}")
-      logger.info(s"Headers: ${request.headers}")
+  private val callWrapper = new CallWrapper[F](config.oneFrame.callWrapper)
+
+  override def get(pair: Rate.Pair): F[Error Either Rate] = {
+
+    // Create an HTTP request with headers
+    val request = GET(
+      buildUri(baseUri, pair),
+      Header.Raw.apply(CIString("token"), token)
+    )
+
+    // Log the request details (URI and headers)
+    logger.debug(s"Created request with URI: ${request.uri}")
+    logger.debug(s"Headers: ${request.headers}")
+    val key = s"${pair.from}${pair.to}"
+
+    // callWrapper to apply memcache n cb
+    callWrapper.call(key) {
       // Send the request and handle the response
       client.run(request).use { response =>
         response.status match {
-          case Status.Ok => 
-            response.as[List[RateResponse]].attempt.flatMap{ 
+          case Status.Ok =>
+            response.as[List[RateResponse]].attempt.flatMap {
               case Right(rateResponses) =>
                 logger.debug(s"Successfully decoded response: ${rateResponses}")
                 val rateResponse = rateResponses.head
@@ -73,10 +78,11 @@ class OneFrameAPI[F[_]: Sync](client: Client[F], config: ApplicationConfig) exte
           case Status.Unauthorized =>
             logger.debug("403")
             Error.OneFrameLookupFailed("Unauthorized").asLeft[Rate].leftMap(identity[Error]).pure[F]
-          case unexpectedStatus => 
+          case unexpectedStatus =>
             logger.debug(s"Unexpected status code: $unexpectedStatus")
             Error.OneFrameLookupFailed("Unexpected response from the API").asLeft[Rate].leftMap(identity[Error]).pure[F]
         }
+      }
     }
   }
 }

--- a/src/main/scala/forex/utils/callWrapper/CallWrapper.scala
+++ b/src/main/scala/forex/utils/callWrapper/CallWrapper.scala
@@ -8,18 +8,22 @@ import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import org.slf4j.LoggerFactory
 import forex.config._
+import cats.effect.concurrent.Ref
+import cats.syntax.functor._
 
-// CallWrapper is the general package to ease the integration with other services.
-// Required define CallWrapperConfig to use this class,
-// it can potentially use to cover more usage like:
+// CallWrapper is a general package to ease integration with other services.
+// Requires defining CallWrapperConfig to use this class.
+// It can potentially be used to cover more usages like:
 // * SingleFlight
 // * Standardize Metric utilization
-class CallWrapper [F[_]: Sync](cfg: CallWrapperConfig) {
+class CallWrapper[F[_]: Sync](cfg: CallWrapperConfig) {
   private val logger = LoggerFactory.getLogger(getClass)
   // Circuit breaker configuration
+  require(cfg.failureRateThreshold >= 0 && cfg.failureRateThreshold <= 100, "failureRateThreshold must be between 0 and 100")
+  require(cfg.waitDurationInOpenState.toSeconds > 0, "waitDurationInOpenState must be positive")
   private val cbConfig = CircuitBreakerConfig.custom()
     .failureRateThreshold(cfg.failureRateThreshold.toFloat) // Use the parameter
-    .waitDurationInOpenState(Duration.ofSeconds(cfg.waitDurationInOpenState)) // Use the parameter
+    .waitDurationInOpenState(Duration.ofSeconds(cfg.waitDurationInOpenState.toSeconds)) // Use the parameter
     .build()
 
   // Create the circuit breaker instance
@@ -27,24 +31,25 @@ class CallWrapper [F[_]: Sync](cfg: CallWrapperConfig) {
     if (cfg.enableCb) Some(CircuitBreaker.of(cfg.cbName, cbConfig)) else None
 
   // In-memory cache
-  private var cache: Map[String, (Instant, Any)] = Map.empty
+  private val cache: Ref[F, Map[String, (Instant, Any)]] = Ref.unsafe(Map.empty[String, (Instant, Any)])
 
   // Function to execute an action with circuit breaker protection
   def call[A](key: String)(action: F[A]): F[A] = {
     if (cfg.enableCache) {
-      // Check if the result is in cache
-      cache.get(key) match {
-        case Some((timestamp, value)) if Instant.now().isBefore(timestamp.plusSeconds(cfg.cacheTTL)) =>
-          // Return cached value
-          Sync[F].pure(value.asInstanceOf[A])
-        case _ =>
-          // Execute action with optional circuit breaker protection
-          executeWithCircuitBreaker(action).flatMap { result =>
-            // Cache the result with the current timestamp
-            cache = cache.updated(key, (Instant.now(), result))
-            Sync[F].pure(result)
-          }
-      }
+      for {
+        currentCache <- cache.get
+        result <- currentCache.get(key) match {
+          case Some((timestamp, value)) if Instant.now().isBefore(timestamp.plusSeconds(cfg.cacheTTL.toSeconds)) =>
+            // Return cached value if TTL is valid
+            Sync[F].pure(value.asInstanceOf[A])
+          case _ =>
+            // Remove expired cache entry and execute the action
+            executeWithCircuitBreaker(action).flatTap { result =>
+              // Cache the result with the current timestamp
+              cache.update(_ + (key -> (Instant.now(), result)))
+            }
+        }
+      } yield result
     }else {
         // If caching is disabled, just execute the action with optional circuit breaker protection
         executeWithCircuitBreaker(action)

--- a/src/main/scala/forex/utils/callWrapper/CallWrapper.scala
+++ b/src/main/scala/forex/utils/callWrapper/CallWrapper.scala
@@ -1,0 +1,75 @@
+package forex.utils.callWrapper
+
+import cats.effect.Sync
+import io.github.resilience4j.circuitbreaker.{CallNotPermittedException, CircuitBreaker, CircuitBreakerConfig}
+
+import java.time.{Duration, Instant}
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import org.slf4j.LoggerFactory
+import forex.config._
+
+// CallWrapper is the general package to ease the integration with other services.
+// Required define CallWrapperConfig to use this class,
+// it can potentially use to cover more usage like:
+// * SingleFlight
+// * Standardize Metric utilization
+class CallWrapper [F[_]: Sync](cfg: CallWrapperConfig) {
+  private val logger = LoggerFactory.getLogger(getClass)
+  // Circuit breaker configuration
+  private val cbConfig = CircuitBreakerConfig.custom()
+    .failureRateThreshold(cfg.failureRateThreshold.toFloat) // Use the parameter
+    .waitDurationInOpenState(Duration.ofSeconds(cfg.waitDurationInOpenState)) // Use the parameter
+    .build()
+
+  // Create the circuit breaker instance
+  private val circuitBreaker: Option[CircuitBreaker] =
+    if (cfg.enableCb) Some(CircuitBreaker.of(cfg.cbName, cbConfig)) else None
+
+  // In-memory cache
+  private var cache: Map[String, (Instant, Any)] = Map.empty
+
+  // Function to execute an action with circuit breaker protection
+  def call[A](key: String)(action: F[A]): F[A] = {
+    if (cfg.enableCache) {
+      // Check if the result is in cache
+      cache.get(key) match {
+        case Some((timestamp, value)) if Instant.now().isBefore(timestamp.plusSeconds(cfg.cacheTTL)) =>
+          // Return cached value
+          Sync[F].pure(value.asInstanceOf[A])
+        case _ =>
+          // Execute action with optional circuit breaker protection
+          executeWithCircuitBreaker(action).flatMap { result =>
+            // Cache the result with the current timestamp
+            cache = cache.updated(key, (Instant.now(), result))
+            Sync[F].pure(result)
+          }
+      }
+    }else {
+        // If caching is disabled, just execute the action with optional circuit breaker protection
+        executeWithCircuitBreaker(action)
+      }
+    }
+
+  // Execute action with optional circuit breaker protection
+  private def executeWithCircuitBreaker[A](action: F[A]): F[A] = {
+    circuitBreaker match {
+      case Some(cb) =>
+        // Execute with circuit breaker
+        Sync[F].delay(cb.executeSupplier(() => action)).flatten.handleErrorWith(handleCircuitBreakerError)
+      case None =>
+        // Execute without circuit breaker
+        action
+    }
+  }
+
+  // Handle errors related to circuit breaker behavior (e.g., when calls are not permitted)
+  private def handleCircuitBreakerError[A](error: Throwable): F[A] = error match {
+    case _: CallNotPermittedException =>
+      logger.warn("Circuit breaker: Call not permitted")
+      Sync[F].raiseError(new RuntimeException("Circuit breaker: Call not permitted. Service is unavailable."))
+    case other =>
+      logger.error(s"Unexpected error: ${other.getMessage}")
+      Sync[F].raiseError(new RuntimeException(s"Unexpected error: ${other.getMessage}"))
+  }
+}


### PR DESCRIPTION
## Motivation: 
With a given one-frame service limitation of about 1000 calls/day, we can use a simple cache with a 5-minute TTL to reduce the call to the service and still fulfill the relevant result based on the requirement. 
with 5 minute TTL cache, the total traffic estimation per day n pair maximum will be
24*60/5 (per pair traffic)*2(sum of pair combination) >= 576 requests. with this approach, there is no limitation of per day calls to our service 

## Changes: 
- add dummy dockerfile. Try to find out how to containerize the project. 
- update Readme.md with Technical Overview aspect
- add circuitBreaker Library 
- update config Object with callWrapper config. 
- new callWrapper package. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `CallWrapper` class for enhanced service integration, featuring circuit breaker functionality and caching.
  - Updated project documentation with clearer descriptions, enhanced structure, and new sections on technical aspects and CI/CD.
  
- **Configuration Changes**
  - Modified port settings for service accessibility and added a new configuration block for call wrapper settings.

- **Bug Fixes**
  - Improved logging for request handling and response management in the API service.

- **Dependency Updates**
  - Added a new circuit breaker library to enhance application resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->